### PR TITLE
LB-124 - Create head block

### DIFF
--- a/react-native-app/pages/components/V2Components/ContentLogoBlock.js
+++ b/react-native-app/pages/components/V2Components/ContentLogoBlock.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import { View, useWindowDimensions } from 'react-native';
+
+/**
+The Content Logo Block contains its content in a left justified view that
+spans its parent container width 100%
+
+//*/
+export default function ContentLogoBlock(props){
+	
+	return (
+		<View style={
+			Object.assign
+			(
+				{
+					flexDirection: 'row',
+					justifyContent: 'flex-start',
+					alignItems: 'flex-end',
+					width: '100%'
+				}, 
+				props.style
+			)
+		}>
+			{props.children}
+		</View>
+	);
+
+
+}

--- a/react-native-app/pages/components/V2Components/NavigationButtonBar.js
+++ b/react-native-app/pages/components/V2Components/NavigationButtonBar.js
@@ -1,0 +1,32 @@
+import * as React from 'react';
+import { View, useWindowDimensions } from 'react-native';
+
+/**
+The NavigationButtonBar takes any items that are placed inside it and
+spreads them evenly across the interior of the container while having 
+first and last items agains the walls of the container
+
+the intended usage of this container is to hold navigation buttons
+
+//*/
+export default function NavigationButtonBar(props){
+	
+	return (
+		<View style={
+			Object.assign
+			(
+				{
+					flexDirection: 'row',
+					justifyContent: 'space-between',
+					alignItems: 'flex-end',
+					width: '80%'
+				}, 
+				props.style
+			)
+		}>
+			{props.children}
+		</View>
+	);
+
+
+}

--- a/react-native-app/pages/components/V2Components/NavigationRow.js
+++ b/react-native-app/pages/components/V2Components/NavigationRow.js
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import { View, useWindowDimensions } from 'react-native';
+
+/**
+The NavigationRow contains the NavigationButtonBar and the button for logging out
+The expected usage is to simply put the NavigationButtonBar inside the NavigationRow
+and the NavigationRow will place the NavigationButtonBar and the button for logging out
+at the ends of the space
+
+//*/
+export default function NavigationRow(props){
+	
+	return (
+		<View style={
+			Object.assign
+			(
+				{
+					flexDirection: 'row',
+					justifyContent: 'space-between',
+					alignItems: 'flex-end',
+					width: '100%'
+				}, 
+				props.style
+			)
+		}>
+			{props.children}
+		</View>
+	);
+
+
+}


### PR DESCRIPTION
Head block couldn't be realistically be built as a single unit yet due to other pending tasks.  Therefore in order to enable development going forward the head block is being done as three components as originally intended but without a parent container that will take all of the expected components as parameters or with the expected components hard-coded into the component

+ContentLogoBlock : for logo and title
+NavigationButtonBar: For the navigation buttons
+NavigationRow: Holds button bar and logoff button